### PR TITLE
Fix init.d template

### DIFF
--- a/templates/init.d.erb
+++ b/templates/init.d.erb
@@ -7,7 +7,7 @@ PID_FILE=/var/run/$NAME.pid
 
 HOSTNAME=$(hostname -f)
 
-DAEMON="java -jar ${EXHIBITOR_HOME}/exhibitor-<%= @version %>-jar-with-dependencies.jar"
+DAEMON="java -jar ${EXHIBITOR_HOME}/exhibitor-<%= scope.lookupvar('::exhibitor::version') %>-jar-with-dependencies.jar"
 DAEMON_OPTS="--hostname ${HOSTNAME} ${EXHIBITOR_OPTS}"
 
 start() {


### PR DESCRIPTION
The template needs to specify the full path to the `version` variable.
`<%= @version %>` worked because of a bug/quirk in Puppet 3.